### PR TITLE
Dont actually install the site with drupal-vm

### DIFF
--- a/starter/config.yml
+++ b/starter/config.yml
@@ -41,7 +41,7 @@ drush_makefile_path: ../../drupal.make.yml
 
 # Set this to false if you don't need to install drupal (using the drupal_*
 # settings below), but instead copy down a database (e.g. using drush sql-sync).
-install_site: true
+install_site: false
 
 # Settings for building a Drupal site from a makefile (if 'build_makefile:'
 # is 'true').


### PR DESCRIPTION
Installing with drupal-vm will overwrite our settings.php which contains
a some customized includes.
